### PR TITLE
Problems related with the field "workratio"

### DIFF
--- a/src/main/java/com/lesstif/jira/issue/IssueFields.java
+++ b/src/main/java/com/lesstif/jira/issue/IssueFields.java
@@ -70,7 +70,7 @@ public class IssueFields {
 	
 	private String[] labels;
 	
-	private Integer workratio;
+	private Long workratio;
 	
 	private String environment;
 	


### PR DESCRIPTION
In some cases the field `workratio` can have a numeric value greater than an Integer