### PR TITLE
JSON deserialization - Adding missing fields

### DIFF
--- a/src/main/java/com/lesstif/jira/issue/Author.java
+++ b/src/main/java/com/lesstif/jira/issue/Author.java
@@ -63,4 +63,26 @@ public class Author extends JsonPrettyString {
 		return name;
 	}
 
+        @org.codehaus.jackson.annotate.JsonProperty("key")
+        private java.lang.String key;
+
+        public void setKey(java.lang.String key) {
+          this.key = key;
+        }
+
+        public java.lang.String getKey() {
+                return key;
+        }
+
+        @org.codehaus.jackson.annotate.JsonProperty("timeZone")
+        private java.lang.String timeZone;
+
+        public void setTimeZone(java.lang.String timeZone) {
+          this.timeZone = timeZone;
+        }
+
+        public java.lang.String getTimeZone() {
+                return timeZone;
+        }
+
 }

--- a/src/main/java/com/lesstif/jira/issue/WorklogElement.java
+++ b/src/main/java/com/lesstif/jira/issue/WorklogElement.java
@@ -40,6 +40,8 @@ public class WorklogElement extends JsonPrettyString implements Comparable<Workl
     private String created;
     @JsonProperty("updated")
     private String updated;
+    @JsonProperty("issueId")
+    private String issueId;
 
     public WorklogElement() {
 


### PR DESCRIPTION
I cannot exactly tell when our JIRA instance stopped functioning in
regards to JSON deserialization, but I needed to add these fields in
both classes to get the different objects working again.

Tests: runtime, no jackson deserialization exception encountered
after this patch.