### PR TITLE
Storing workratio as Double instead of Integer

### DIFF
--- a/src/main/java/com/lesstif/jira/issue/IssueFields.java
+++ b/src/main/java/com/lesstif/jira/issue/IssueFields.java
@@ -69,9 +69,9 @@ public class IssueFields {
 	private Status status;
 	
 	private String[] labels;
-	
-	private Integer workratio;
-	
+
+	private Double workratio;
+
 	private String environment;
 	
 	private List<Component> components;


### PR DESCRIPTION
Our JIRA api sometimes returns workratio in numbers out of range for the
class Integer, switching to Double solves the issue.

Here is the stacktrace received sticking with Integer:

```
org.codehaus.jackson.JsonParseException: Numeric value (9223372036854775807) out of range of int
 at [Source: java.io.StringReader@17ca4559; line: 1, column: 1483]
	at org.codehaus.jackson.JsonParser._constructError(JsonParser.java:1291) ~[jackson-core-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.impl.JsonParserMinimalBase._reportError(JsonParserMinimalBase.java:385) ~[jackson-core-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.impl.JsonNumericParserBase.convertNumberToInt(JsonNumericParserBase.java:462) ~[jackson-core-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.impl.JsonNumericParserBase.getIntValue(JsonNumericParserBase.java:257) ~[jackson-core-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.StdDeserializer._parseInteger(StdDeserializer.java:237) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.StdDeserializer$IntegerDeserializer.deserialize(StdDeserializer.java:838) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.StdDeserializer$IntegerDeserializer.deserialize(StdDeserializer.java:825) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:252) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.SettableBeanProperty$MethodProperty.deserializeAndSet(SettableBeanProperty.java:356) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:494) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.BeanDeserializer.deserialize(BeanDeserializer.java:350) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:252) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.SettableBeanProperty$MethodProperty.deserializeAndSet(SettableBeanProperty.java:356) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:494) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.deser.BeanDeserializer.deserialize(BeanDeserializer.java:350) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.ObjectMapper._readMapAndClose(ObjectMapper.java:2395) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at org.codehaus.jackson.map.ObjectMapper.readValue(ObjectMapper.java:1602) ~[jackson-mapper-asl-1.8.3.jar:1.8.3]
	at com.lesstif.jira.services.IssueService.getIssue(IssueService.java:69) ~[jira-rest-api-0.8.2.jar:na]
```

No deserialization issue so far replacing Integer by Double as in the PR.
